### PR TITLE
bcdb: fix model.get by always setting obj_id as an integer...

### DIFF
--- a/JumpscaleCore/data/bcdb/BCDBModel.py
+++ b/JumpscaleCore/data/bcdb/BCDBModel.py
@@ -508,6 +508,7 @@ class BCDBModel(j.baseclasses.object):
         #             # print("cache hit")
         #             return obj
 
+        obj_id = int(obj_id) # make sure obj_id is always an integer
         data = self.storclient.get(obj_id)
 
         if not data:
@@ -517,7 +518,6 @@ class BCDBModel(j.baseclasses.object):
                 return None
 
         obj = self.bcdb._unserialize(obj_id, data, return_as_capnp=return_as_capnp)
-
         if obj._schema.url == self._schema_url:
             obj = self._triggers_call(obj=obj, action="get")
         else:

--- a/JumpscaleCore/data/bcdb/connectors/webdav/BCDBFSProvider.py
+++ b/JumpscaleCore/data/bcdb/connectors/webdav/BCDBFSProvider.py
@@ -170,9 +170,9 @@ class BCDBFSProvider(DAVProvider):
     def __init__(self, bcdb_name):
         DAVProvider.__init__(self)
         self._bcdb = j.data.bcdb.get(bcdb_name)
-        self._file_model = self._bcdb.model_get_from_file("{}/models_system/FILE.py".format(self._bcdb._dirpath))
-        self._dir_model = self._bcdb.model_get_from_file("{}/models_system/DIR.py".format(self._bcdb._dirpath))
-        self._block_model = self._bcdb.model_get_from_file("{}/models_system/BLOCK.py".format(self._bcdb._dirpath))
+        self._file_model = self._bcdb.model_get_from_file("{}/models_threebot/FILE.py".format(self._bcdb._dirpath))
+        self._dir_model = self._bcdb.model_get_from_file("{}/models_threebot/DIR.py".format(self._bcdb._dirpath))
+        self._block_model = self._bcdb.model_get_from_file("{}/models_threebot/BLOCK.py".format(self._bcdb._dirpath))
 
     def get_resource_inst(self, path, environ):
         """

--- a/JumpscaleCore/data/bcdb/tests/16_fs.py
+++ b/JumpscaleCore/data/bcdb/tests/16_fs.py
@@ -88,8 +88,8 @@ def main(self):
     start_cmd = """
     from Jumpscale import j
     rack = j.servers.rack.get()
-    from jumpscale.Jumpscale.data.bcdb.connectors.webdav.BCDBFSProvider import BCDBFSProvider
-    
+    from Jumpscale.data.bcdb.connectors.webdav.BCDBFSProvider import BCDBFSProvider
+
     rack.webdav_server_add(webdavprovider=BCDBFSProvider("test_fs"), port=4444)
     rack.start()
     """

--- a/JumpscaleCore/data/schema/JSXObject.py
+++ b/JumpscaleCore/data/schema/JSXObject.py
@@ -234,7 +234,7 @@ class JSXObject(j.baseclasses.object):
         return self._data == val._data
 
     def __hash__(self):
-        return j.data.hash.md5_string(self._data)
+        return hash(j.data.hash.md5_string(self._data))
         # return int(self.id)
         # CANNOT DO THIS it does not mean its the same
         # WHY DO WE NEED THIS?


### PR DESCRIPTION
We just put the passed obj_id to `BCDBModel.get` as obj.id for the returned object, so, it'd have a string id if the passed obj_id is a `str`.

Also return an integer for `JSXObject.__hash__` and fix the path of fs models.

This would resolve errors like this:

```
JSX> j.data.bcdb.test(name="fs")                                                                                                                      
fs
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/sandbox/lib/jumpscale/Jumpscale/data/bcdb/BCDBFactory.py", line 480, in test
    self._test_run(name=name)
  File "/sandbox/lib/jumpscale/Jumpscale/core/BASECLASSES/TestTools.py", line 53, in _test_run
    res = self.__test_run(name=name, obj_key=obj_key, die=die, **kwargs)
  File "/sandbox/lib/jumpscale/Jumpscale/core/BASECLASSES/TestTools.py", line 140, in __test_run
    self._code_run(name=name, path=tpath, obj_key=obj_key, die=die, **kwargs)
  File "/sandbox/lib/jumpscale/Jumpscale/core/BASECLASSES/TestTools.py", line 75, in _code_run
    res = method(self=self, **kwargs)
  File "/sandbox/lib/jumpscale/Jumpscale/data/bcdb/tests/16_fs.py", line 77, in main
    res = file_model.files_search(tags="color:blue")
  File "/sandbox/lib/jumpscale/Jumpscale/data/bcdb/models_threebot/FILE.py", line 72, in files_search
    self._do_search(**dict(type=type, tags=tags, extension=extension, content=content, description=description))
  File "/sandbox/lib/jumpscale/Jumpscale/data/bcdb/models_threebot/FILE.py", line 81, in _do_search
    return self._do_search(**kwargs)
  File "/sandbox/lib/jumpscale/Jumpscale/data/bcdb/models_threebot/FILE.py", line 81, in _do_search
    return self._do_search(**kwargs)
  File "/sandbox/lib/jumpscale/Jumpscale/data/bcdb/models_threebot/FILE.py", line 81, in _do_search
    return self._do_search(**kwargs)
  File "/sandbox/lib/jumpscale/Jumpscale/data/bcdb/models_threebot/FILE.py", line 98, in _do_search
    return set(res)
  File "/sandbox/lib/jumpscale/Jumpscale/data/schema/JSXObject.py", line 237, in __hash__
    return j.data.hash.md5_string(self._data)
  File "/sandbox/lib/jumpscale/Jumpscale/data/schema/JSXObject.py", line 201, in _data
    return j.data.serializers.jsxdata.dumps(self)
  File "/sandbox/lib/jumpscale/Jumpscale/data/serializers/SerializerJSXObject.py", line 43, in dumps
    assert u.id == obj.id
AssertionError
```