### PR TITLE
Development baseclasses #19

### DIFF
--- a/JumpscaleCore/core/BASECLASSES/JSConfigBCDB.py
+++ b/JumpscaleCore/core/BASECLASSES/JSConfigBCDB.py
@@ -85,7 +85,7 @@ class JSConfigBCDB(JSConfigBCDBBase):
                 child_class_inst = self._children[child_class]
                 if child_class_inst._children:
                     for child in child_class_inst._children._data.copy():
-                        child_class_inst.delete(child)
+                        child_class_inst._children[child].delete()
         self._triggers_call(self, "delete_post")
 
     def save(self):

--- a/JumpscaleCore/core/BASECLASSES/JSConfigBCDB.py
+++ b/JumpscaleCore/core/BASECLASSES/JSConfigBCDB.py
@@ -80,12 +80,9 @@ class JSConfigBCDB(JSConfigBCDBBase):
             if self._data.name in self._parent._children:
                 del self._parent._children[self._data.name]
 
-        if self._children:
-            for child_class in self._children:
-                child_class_inst = self._children[child_class]
-                if child_class_inst._children:
-                    for child in child_class_inst._children._data.copy():
-                        child_class_inst._children[child].delete()
+        for key,child_class in self._children.items():
+            child_class.delete()
+
         self._triggers_call(self, "delete_post")
 
     def save(self):

--- a/JumpscaleCore/core/BASECLASSES/JSConfigBCDB.py
+++ b/JumpscaleCore/core/BASECLASSES/JSConfigBCDB.py
@@ -80,8 +80,12 @@ class JSConfigBCDB(JSConfigBCDBBase):
             if self._data.name in self._parent._children:
                 del self._parent._children[self._data.name]
 
-        for key,child_class in self._children.items():
-            child_class.delete()
+        if self._children:
+            for child_class in self._children:
+                child_class_inst = self._children[child_class]
+                if child_class_inst._children:
+                    for child in child_class_inst._children._data.copy():
+                        child_class_inst._children[child].delete()
 
         self._triggers_call(self, "delete_post")
 

--- a/JumpscaleCore/core/BASECLASSES/JSConfigBCDB.py
+++ b/JumpscaleCore/core/BASECLASSES/JSConfigBCDB.py
@@ -79,6 +79,13 @@ class JSConfigBCDB(JSConfigBCDBBase):
         if self._parent:
             if self._data.name in self._parent._children:
                 del self._parent._children[self._data.name]
+
+        if self._children:
+            for child_class in self._children:
+                child_class_inst = self._children[child_class]
+                if child_class_inst._children:
+                    for child in child_class_inst._children._data.copy():
+                        child_class_inst.delete(child)
         self._triggers_call(self, "delete_post")
 
     def save(self):


### PR DESCRIPTION
Issue: 
https://github.com/threefoldtech/jumpscaleX_core/issues/19#issuecomment-526912857
Example:
```python
cl = j.clients.tfchain.get("test_cl")
cl.save()
cl_wallet = cl.wallets.get("test_cl_wallet") 
cl_wallet.save()
cl.delete()
# now test_cl is deleted but test_cl_wallet is still saved with the mother_id as cl's id but the instance with that id is deleted
# there is no cl.wallets.get(.....) anymore
```
Fix:
Delete children if available in the delete() function of JSConfigBCDB
note: for the previous example when deleting `cl`, `cl_wallet` should be deleted as well
