### PR TITLE
WIP: fix loading of modules twice...

### DIFF
--- a/JumpscaleCore/__init__.py
+++ b/JumpscaleCore/__init__.py
@@ -285,13 +285,6 @@ if not os.path.exists(j.core.application._lib_generation_path):
     j.core.jsgenerator.report()
     generated = True
 
-ipath = j.core.tools.text_replace("{DIR_BASE}/lib/jumpscale/Jumpscale")
-if ipath not in sys.path:
-    sys.path.append(ipath)
-
-ipath = j.core.tools.text_replace("{DIR_BASE}/lib/jumpscale")
-if ipath not in sys.path:
-    sys.path.append(ipath)
 
 import jumpscale_generated
 

--- a/JumpscaleCore/clients/redis/RedisFactory.py
+++ b/JumpscaleCore/clients/redis/RedisFactory.py
@@ -5,8 +5,8 @@ from redis._compat import nativestr
 
 from Jumpscale import j
 
-from core.InstallTools import Redis
-from core.InstallTools import RedisTools
+from Jumpscale.core.InstallTools import Redis
+from Jumpscale.core.InstallTools import RedisTools
 
 
 class RedisFactory(j.baseclasses.factory):


### PR DESCRIPTION
see https://github.com/threefoldtech/jumpscaleX_core/issues/61#issuecomment-529372134

Closes #61.

This PR is put to WIP because some other places still directly import `Jumpscale` sub-modules like:

https://github.com/threefoldtech/jumpscaleX_libs/blob/master/JumpscaleLibs/data/flist/models/DirCollection.py#L3

IMHO, we should not do this!