### PR TITLE
Pull the latest docker image when installing inside a container

### DIFF
--- a/install/InstallTools.py
+++ b/install/InstallTools.py
@@ -4552,6 +4552,11 @@ class DockerContainer:
 
         if not self.container_exists:
 
+            # First make sure the latest docker image is present
+            run_image_update_cmd = Tools.text_replace("docker image pull {IMAGE}", args=args)
+            Tools.execute(run_image_update_cmd, interactive=False)
+
+            # Now create the container
             MOUNTS = ""
             if mount_dirs:
                 MOUNTS = """


### PR DESCRIPTION
docker container create only checks if the "latest" tag is available locally, it does not pull an updated image.
I suggest to do a docker image pull before creating the container to avoid this. It does no harm since it does nothing if the image is up to date.

Fixes issue #80 
