### PR TITLE
Convention for static/spa locations in the packages

### DIFF
--- a/JumpscaleCore/tools/threebot_package/ThreeBotPackage.py
+++ b/JumpscaleCore/tools/threebot_package/ThreeBotPackage.py
@@ -152,9 +152,6 @@ class ThreeBotPackage(JSConfigBase):
                 locations.configure()
                 website.configure()
 
-                # setup alert handler to intercept errors
-                j.tools.alerthandler.setup()
-
     @property
     def bcdb(self):
         return self._package_author.bcdb

--- a/JumpscaleCore/tools/threebot_package/ThreeBotPackage.py
+++ b/JumpscaleCore/tools/threebot_package/ThreeBotPackage.py
@@ -79,6 +79,7 @@ class ThreeBotPackage(JSConfigBase):
 
         self._init_ = True
 
+<<<<<<< HEAD
     def _check_app_type(self):
         html_location = j.sal.fs.joinPaths(self.path, "html")
         frontend_location = j.sal.fs.joinPaths(self.path, "frontend")
@@ -92,10 +93,21 @@ class ThreeBotPackage(JSConfigBase):
             return
         app_type = self._check_app_type()
         if app_type:
+=======
+    def _check_frontend(self):
+        html_location = j.sal.fs.joinPaths(self.path, "html")
+        if j.sal.fs.exists(html_location):
+            return True
+        return False
+
+    def _create_locations(self):
+        if self.path and self._check_frontend():
+>>>>>>> Moved location creation to ThreebotPackage for packages that have html dir
             for port in (443, 80):
                 website = self.openresty.get_from_port(port)
 
                 locations = website.locations.get(f"{self.name}_locations")
+<<<<<<< HEAD
                 if app_type == "frontend":
                     website_location = locations.locations_spa.new()
                 elif app_type == "html":
@@ -105,6 +117,14 @@ class ThreeBotPackage(JSConfigBase):
                 website_location.path_url = f"/{self.name}"
                 website_location.use_jumpscale_weblibs = False
                 fullpath = j.sal.fs.joinPaths(self.path, f"{app_type}/")
+=======
+
+                website_location = locations.locations_spa.new()
+                website_location.name = self.name
+                website_location.path_url = f"/{self.name}"
+                website_location.use_jumpscale_weblibs = False
+                fullpath = j.sal.fs.joinPaths(self.path, "html/")
+>>>>>>> Moved location creation to ThreebotPackage for packages that have html dir
                 website_location.path_location = fullpath
 
                 locations.configure()
@@ -125,6 +145,7 @@ class ThreeBotPackage(JSConfigBase):
         self._create_locations()
         self._init_before_action()
         self._package_author.start()
+        self._create_locations()
         self.status = "running"
         self.save()
 

--- a/JumpscaleCore/tools/threebot_package/ThreeBotPackage.py
+++ b/JumpscaleCore/tools/threebot_package/ThreeBotPackage.py
@@ -167,7 +167,6 @@ class ThreeBotPackage(JSConfigBase):
         self._create_locations()
         self._init_before_action()
         self._package_author.start()
-        self._create_locations()
         self.status = "running"
         self.save()
 

--- a/JumpscaleCore/tools/threebot_package/ThreeBotPackage.py
+++ b/JumpscaleCore/tools/threebot_package/ThreeBotPackage.py
@@ -122,9 +122,9 @@ class ThreeBotPackage(JSConfigBase):
         self._package_author.prepare()
 
     def start(self):
+        self._create_locations()
         self._init_before_action()
         self._package_author.start()
-        self._create_locations()
         self.status = "running"
         self.save()
 

--- a/JumpscaleCore/tools/threebot_package/ThreeBotPackage.py
+++ b/JumpscaleCore/tools/threebot_package/ThreeBotPackage.py
@@ -77,76 +77,36 @@ class ThreeBotPackage(JSConfigBase):
                 name = self.name
                 j.servers.myjobs.schedule(load_wiki, wiki_name=name, wiki_path=path)
 
+            self._create_locations()
+
         self._init_ = True
 
-<<<<<<< HEAD
-<<<<<<< HEAD
     def _check_app_type(self):
         html_location = j.sal.fs.joinPaths(self.path, "html")
         frontend_location = j.sal.fs.joinPaths(self.path, "frontend")
-        if j.sal.fs.exists(html_location):
-            return "html"
-        elif j.sal.fs.exists(frontend_location):
+        if j.sal.fs.exists(frontend_location):
             return "frontend"
+        elif j.sal.fs.exists(html_location):
+            return "html"
 
     def _create_locations(self):
         if not self.path:
             return
         app_type = self._check_app_type()
         if app_type:
-=======
-    def _check_frontend(self):
-=======
-    def _check_app_type(self):
->>>>>>> Add location creation for apps with html or frontend
-        html_location = j.sal.fs.joinPaths(self.path, "html")
-        frontend_location = j.sal.fs.joinPaths(self.path, "frontend")
-        if j.sal.fs.exists(html_location):
-            return "html"
-        elif j.sal.fs.exists(frontend_location):
-            return "frontend"
-
-    def _create_locations(self):
-<<<<<<< HEAD
-        if self.path and self._check_frontend():
->>>>>>> Moved location creation to ThreebotPackage for packages that have html dir
-=======
-        if not self.path:
-            return
-        app_type = self._check_app_type()
-        if app_type:
->>>>>>> Add location creation for apps with html or frontend
             for port in (443, 80):
                 website = self.openresty.get_from_port(port)
 
                 locations = website.locations.get(f"{self.name}_locations")
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Add location creation for apps with html or frontend
                 if app_type == "frontend":
                     website_location = locations.locations_spa.new()
                 elif app_type == "html":
                     website_location = locations.locations_static.new()
-<<<<<<< HEAD
 
                 website_location.name = self.name
                 website_location.path_url = f"/{self.name}"
                 website_location.use_jumpscale_weblibs = False
                 fullpath = j.sal.fs.joinPaths(self.path, f"{app_type}/")
-=======
-=======
->>>>>>> Add location creation for apps with html or frontend
-
-                website_location.name = self.name
-                website_location.path_url = f"/{self.name}"
-                website_location.use_jumpscale_weblibs = False
-<<<<<<< HEAD
-                fullpath = j.sal.fs.joinPaths(self.path, "html/")
->>>>>>> Moved location creation to ThreebotPackage for packages that have html dir
-=======
-                fullpath = j.sal.fs.joinPaths(self.path, f"{app_type}/")
->>>>>>> Add location creation for apps with html or frontend
                 website_location.path_location = fullpath
 
                 locations.configure()
@@ -161,7 +121,6 @@ class ThreeBotPackage(JSConfigBase):
         self._package_author.prepare()
 
     def start(self):
-        self._create_locations()
         self._init_before_action()
         self._package_author.start()
         self.status = "running"

--- a/JumpscaleCore/tools/threebot_package/ThreeBotPackage.py
+++ b/JumpscaleCore/tools/threebot_package/ThreeBotPackage.py
@@ -80,6 +80,7 @@ class ThreeBotPackage(JSConfigBase):
         self._init_ = True
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     def _check_app_type(self):
         html_location = j.sal.fs.joinPaths(self.path, "html")
         frontend_location = j.sal.fs.joinPaths(self.path, "frontend")
@@ -95,36 +96,57 @@ class ThreeBotPackage(JSConfigBase):
         if app_type:
 =======
     def _check_frontend(self):
+=======
+    def _check_app_type(self):
+>>>>>>> Add location creation for apps with html or frontend
         html_location = j.sal.fs.joinPaths(self.path, "html")
+        frontend_location = j.sal.fs.joinPaths(self.path, "frontend")
         if j.sal.fs.exists(html_location):
-            return True
-        return False
+            return "html"
+        elif j.sal.fs.exists(frontend_location):
+            return "frontend"
 
     def _create_locations(self):
+<<<<<<< HEAD
         if self.path and self._check_frontend():
 >>>>>>> Moved location creation to ThreebotPackage for packages that have html dir
+=======
+        if not self.path:
+            return
+        app_type = self._check_app_type()
+        if app_type:
+>>>>>>> Add location creation for apps with html or frontend
             for port in (443, 80):
                 website = self.openresty.get_from_port(port)
 
                 locations = website.locations.get(f"{self.name}_locations")
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> Add location creation for apps with html or frontend
                 if app_type == "frontend":
                     website_location = locations.locations_spa.new()
                 elif app_type == "html":
                     website_location = locations.locations_static.new()
+<<<<<<< HEAD
 
                 website_location.name = self.name
                 website_location.path_url = f"/{self.name}"
                 website_location.use_jumpscale_weblibs = False
                 fullpath = j.sal.fs.joinPaths(self.path, f"{app_type}/")
 =======
+=======
+>>>>>>> Add location creation for apps with html or frontend
 
-                website_location = locations.locations_spa.new()
                 website_location.name = self.name
                 website_location.path_url = f"/{self.name}"
                 website_location.use_jumpscale_weblibs = False
+<<<<<<< HEAD
                 fullpath = j.sal.fs.joinPaths(self.path, "html/")
 >>>>>>> Moved location creation to ThreebotPackage for packages that have html dir
+=======
+                fullpath = j.sal.fs.joinPaths(self.path, f"{app_type}/")
+>>>>>>> Add location creation for apps with html or frontend
                 website_location.path_location = fullpath
 
                 locations.configure()


### PR DESCRIPTION
Add convention for static/spa locations in the packages.

Issue: https://github.com/threefoldtech/jumpscaleX_threebot/issues/190

To minimize package.py code, the location creation is done in ThreebotPackage.py based on the dir structure of the packages being loaded where they contain /html directory for static apps or they contain /frontend fir for spa apps