### PR TITLE
Add loading bar to gedis chat bot to be used in chatflows

### DIFF
--- a/JumpscaleCore/servers/gedis/GedisChatBot.py
+++ b/JumpscaleCore/servers/gedis/GedisChatBot.py
@@ -302,6 +302,22 @@ class GedisChatBotSession(JSBASE):
         message["cat"] = "md_show_update"
         self.q_out.put(message)
 
+    def loading_show(self, title, wait, **kwargs):
+        load_html = """\
+# Loading {1}...
+<div class="progress">
+<div class="progress-bar active" role="progressbar" aria-valuenow="{0}"
+aria-valuemin="0" aria-valuemax="100" style="width:{0}%">
+{0}%
+</div>
+</div>
+"""
+        for x in range(wait):
+            message = self.md_msg(load_html.format((x / wait) * 100, title), **kwargs)
+            message["cat"] = "md_show_update"
+            self.q_out.put(message)
+            gevent.sleep(1)
+
     def redirect(self, msg, **kwargs):
         """
         a special helper method to redirect the user to a specific url.


### PR DESCRIPTION
Add bot option of loading bar in chatbot, to be used in chatflows(referenced from https://github.com/threefoldtech/jumpscaleX_core/blob/development/JumpscaleCore/servers/threebot/base_chatflows/food_get.py#L9-L24 ) 

issue related: https://github.com/threefoldtech/jumpscaleX_threebot/issues/147

The option can be used on the bot as the following:
```
bot.loading_show(MESSAGE_LOADING, WAIT_TIME)
```