### PR TITLE
Fixing the importing in BCDB #222

### DIFF
--- a/JumpscaleCore/data/bcdb/BCDB.py
+++ b/JumpscaleCore/data/bcdb/BCDB.py
@@ -231,6 +231,7 @@ class BCDB(j.baseclasses.object):
             if self.storclient:
                 if self.storclient.get(key=i - 1) is None:
                     obj = model.new()
+                    obj.name = j.data.idgenerator.generateGUID()
                     obj.id = None
                     obj.save()
             if i in data:


### PR DESCRIPTION
Fixing the BCDB importing by making the name of the empty model unique.
Fixes https://github.com/threefoldtech/jumpscaleX_threebot/issues/222 