### PR TITLE
Increase threebot server timeout

### DIFF
--- a/JumpscaleCore/servers/threebot/ThreeBotServersFactory.py
+++ b/JumpscaleCore/servers/threebot/ThreeBotServersFactory.py
@@ -42,7 +42,7 @@ class ThreeBotServersFactory(j.baseclasses.object_config_collection_testtools):
     def bcdb_get(self, name, secret="", use_zdb=False):
         return self.default.bcdb_get(name, secret, use_zdb)
 
-    def local_start_default(self, web=True, packages_add=False, timeout=120):
+    def local_start_default(self, web=True, packages_add=False, timeout=600):
         """
 
         kosmos -p 'j.servers.threebot.local_start_default()'

--- a/JumpscaleCore/servers/threebot/ThreebotServer.py
+++ b/JumpscaleCore/servers/threebot/ThreebotServer.py
@@ -102,7 +102,7 @@ class ThreeBotServer(j.baseclasses.object_config):
         locations.configure()
         website.configure()
 
-    def start(self, background=False, web=None, ssl=None, timeout=120):
+    def start(self, background=False, web=None, ssl=None, timeout=600):
         """
 
         kosmos -p 'j.servers.threebot.default.start(background=True,web=False)'

--- a/utils/flist.sh
+++ b/utils/flist.sh
@@ -43,5 +43,6 @@ chmod +x /tmp/jsx;
 /tmp/jsx configure -s --secret mysecret;
 # install
 /tmp/jsx install -s --threebot;
+kosmos -p "j.servers.threebot.local_start_default()"
 
 tar -cpzf "/tmp/archives/JSX.tar.gz" --exclude dev --exclude sys --exclude proc --exclude tmp/archives/ /


### PR DESCRIPTION
Increase threebot server timeout to 10 mins as it is blocking for new installations.