### PR TITLE
Fix issues related to save function in JSXObject.py #171

### DIFF
--- a/JumpscaleCore/data/bcdb/tests/18_save.py
+++ b/JumpscaleCore/data/bcdb/tests/18_save.py
@@ -49,8 +49,8 @@ def main(self):
     schema_obj2.name = "test2"
     schema_obj2.number = 55
     schema_obj2.save()
-    assert type(schema_obj.id) is int
-    assert type(schema_obj2.id) is int
+    assert isinstance(schema_obj.id, int)
+    assert isinstance(schema_obj2.id, int)
 
     # Scenario 2
     # Saving an object with already exist name (Not unique name)
@@ -71,7 +71,7 @@ def main(self):
     # Update already saved object
     schema_obj2.number = 5500
     schema_obj2.save()
-    assert type(schema_obj2.id) is int
+    assert isinstance(schema_obj2.id, int)
 
     # Scenraio 5
     # Update already saved object with not unique name

--- a/JumpscaleCore/data/bcdb/tests/18_save.py
+++ b/JumpscaleCore/data/bcdb/tests/18_save.py
@@ -19,6 +19,7 @@
 
 
 from Jumpscale import j
+from unittest import TestCase
 
 
 def main(self):
@@ -27,6 +28,7 @@ def main(self):
     kosmos 'j.data.bcdb.test(name="save")'
 
     """
+    test_case = TestCase()
 
     scm = """
         @url = test.schema.1
@@ -55,19 +57,15 @@ def main(self):
     schema_obj3 = model.new()
     schema_obj3.name = "test2"
     schema_obj3.number = 55
-    try:
+    with test_case.assertRaises(j.exceptions.Input):
         schema_obj3.save()
-    except:
-        assert Exception
 
     # Scenario 3
     # Saving an object with empty name while it has a name in its schema
     schema_obj4 = model.new()
     schema_obj4.number = 55
-    try:
+    with test_case.assertRaises(j.exceptions.Input):
         schema_obj3.save()
-    except:
-        assert Exception
 
     # Scenario 4
     # Update already saved object
@@ -78,7 +76,5 @@ def main(self):
     # Scenraio 5
     # Update already saved object with not unique name
     schema_obj2.name = "test1"
-    try:
+    with test_case.assertRaises(j.exceptions.Input):
         schema_obj2.save()
-    except:
-        assert Exception

--- a/JumpscaleCore/data/bcdb/tests/18_save.py
+++ b/JumpscaleCore/data/bcdb/tests/18_save.py
@@ -1,0 +1,84 @@
+# Copyright (C) July 2018:  TF TECH NV in Belgium see https://www.threefold.tech/
+# In case TF TECH NV ceases to exist (e.g. because of bankruptcy)
+#   then Incubaid NV also in Belgium will get the Copyright & Authorship for all changes made since July 2018
+#   and the license will automatically become Apache v2 for all code related to Jumpscale & DigitalMe
+# This file is part of jumpscale at <https://github.com/threefoldtech>.
+# jumpscale is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# jumpscale is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License v3 for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with jumpscale or jumpscale derived works.  If not, see <http://www.gnu.org/licenses/>.
+# LICENSE END
+
+
+from Jumpscale import j
+
+
+def main(self):
+    """
+    to run:
+    kosmos 'j.data.bcdb.test(name="save")'
+
+    """
+
+    scm = """
+        @url = test.schema.1
+         name** = "" (S)
+         number = (I)
+         """
+
+    # Scenario 1
+    # Saving two objects with different names
+    schema = j.data.schema.get_from_text(scm)
+    bcdb = j.data.bcdb.get("test")
+    model = bcdb.model_get(schema=schema)
+    schema_obj = model.new()
+    schema_obj.name = "test1"
+    schema_obj.number = 10
+    schema_obj.save()
+    schema_obj2 = model.new()
+    schema_obj2.name = "test2"
+    schema_obj2.number = 55
+    schema_obj2.save()
+    assert type(schema_obj.id) is int
+    assert type(schema_obj2.id) is int
+
+    # Scenario 2
+    # Saving an object with already exist name (Not unique name)
+    schema_obj3 = model.new()
+    schema_obj3.name = "test2"
+    schema_obj3.number = 55
+    try:
+        schema_obj3.save()
+    except:
+        assert Exception
+
+    # Scenario 3
+    # Saving an object with empty name while it has a name in its schema
+    schema_obj4 = model.new()
+    schema_obj4.number = 55
+    try:
+        schema_obj3.save()
+    except:
+        assert Exception
+
+    # Scenario 4
+    # Update already saved object
+    schema_obj2.number = 5500
+    schema_obj2.save()
+    assert type(schema_obj2.id) is int
+
+    # Scenraio 5
+    # Update already saved object with not unique name
+    schema_obj2.name = "test1"
+    try:
+        schema_obj2.save()
+    except:
+        assert Exception

--- a/JumpscaleCore/data/bcdb/tests/18_save.py
+++ b/JumpscaleCore/data/bcdb/tests/18_save.py
@@ -49,8 +49,11 @@ def main(self):
     schema_obj2.name = "test2"
     schema_obj2.number = 55
     schema_obj2.save()
-    assert isinstance(schema_obj.id, int)
-    assert isinstance(schema_obj2.id, int)
+    if not isinstance(schema_obj.id, int):
+        raise AssertionError("Error happened during saving")
+
+    if not isinstance(schema_obj2.id, int):
+        raise AssertionError("Error happened during saving")
 
     # Scenario 2
     # Saving an object with already exist name (Not unique name)
@@ -71,7 +74,8 @@ def main(self):
     # Update already saved object
     schema_obj2.number = 5500
     schema_obj2.save()
-    assert isinstance(schema_obj2.id, int)
+    if not isinstance(schema_obj2.id, int):
+        raise AssertionError("Error happened during saving")
 
     # Scenraio 5
     # Update already saved object with not unique name

--- a/JumpscaleCore/data/bcdb/tests/4_models.py
+++ b/JumpscaleCore/data/bcdb/tests/4_models.py
@@ -48,6 +48,7 @@ def main(self):
     schema_md5 = model.schema._md5
 
     model_obj = model.new()
+    model_obj.name = "house1"
     model_obj.cost = "10 USD"
     model_obj.save()
 

--- a/JumpscaleCore/data/bcdb/tests/6_sqlitestor_base.py
+++ b/JumpscaleCore/data/bcdb/tests/6_sqlitestor_base.py
@@ -45,6 +45,7 @@ def main(self):
     assert model.find() == []
 
     model_obj = model.new()
+    model_obj.name = "house1"
     model_obj.cost = "10 USD"
     model_obj.save()
     # model.cache_reset()

--- a/JumpscaleCore/data/schema/JSXObject.py
+++ b/JumpscaleCore/data/schema/JSXObject.py
@@ -143,6 +143,9 @@ class JSXObject(j.baseclasses.object):
         return out
 
     def save(self, serialize=False):
+        if hasattr(self, "name") and not self.name:
+            raise j.exceptions.Input("Name can't be empty")
+
         if self._changed:
             self._capnp_obj  # makes sure we get back to binary form
             if serialize:
@@ -155,7 +158,7 @@ class JSXObject(j.baseclasses.object):
                     self._deserialized_items["ACL"] = True
 
             if self._changed:
-
+                objects = self._model.find()
                 # WE NEED UNIQUE PROPERTIES
                 for prop_u in self._model.schema.properties_unique:
                     r = []
@@ -163,9 +166,9 @@ class JSXObject(j.baseclasses.object):
                     # unique properties have to be indexed
                     args_search = {prop_u.name: getattr(self, prop_u.name)}
                     if "name" not in args_search:
-                        for model in self._model.find():
-                            m = getattr(model, prop_u.name)
-                            if m == args_search[prop_u.name] and model.id != self.id:
+                        for obj in objects:
+                            m = getattr(obj, prop_u.name)
+                            if m == args_search[prop_u.name] and obj.id != self.id:
                                 msg = "could not save, was not unique.\n%s." % (args_search)
                                 # can for sure not be ok
                                 raise j.exceptions.Input(msg)
@@ -178,16 +181,8 @@ class JSXObject(j.baseclasses.object):
                         raise j.exceptions.Input(msg)
                     elif len(r) == 1:
                         msg = "could not save, was not unique.\n%s." % (args_search)
-                        if self.id:
-                            if not self.id == r[0].id:
-                                raise j.exceptions.Input(msg)
-                        else:
-                            self.id = r[0].id
-                            self._ddict_hr  # to trigger right serialization
-                            if self._data == r[0]._data:
-                                return self  # means data was not changed
-                            else:  # means data is not the same and id not known yet
-                                self.id = r[0].id
+                        if (self.id and not self.id == r[0].id) or not self.id:
+                            raise j.exceptions.Input(msg)
 
                 if not self._nosave:
                     o = self._model.set(self)


### PR DESCRIPTION
* Prevent saving object without a name if it's schema has a name.
* Prevent adding or updating new object with a name that already exists. (it must be unique)
* Adding test scenarios ```18_save.py```
* Fix the tests which were affected by the changes ```4_models.py``` and ```6_sqlitestor_base.py``` 

needed for https://github.com/threefoldtech/jumpscaleX_core/issues/171 