### PR TITLE
Add production image to image builder

### DIFF
--- a/install/InstallTools.py
+++ b/install/InstallTools.py
@@ -5125,6 +5125,14 @@ class DockerContainer:
         cmd = "docker push %s" % image
         Tools.execute(cmd)
 
+    def install_threebotserver(self):
+        """
+        Starts then stops the threebotserver to make sure all needed packages are installed
+        """
+        self.sshexec(
+            ". /sandbox/env.sh; kosmos -p 'j.servers.threebot.local_start_default(web=True); j.servers.threebot.default.stop()'"
+        )
+
     def jumpscale_install(
         self, secret=None, privatekey=None, redo=False, threebot=True, pull=False, branch=None, prebuilt=False
     ):

--- a/install/jsx.py
+++ b/install/jsx.py
@@ -478,8 +478,9 @@ def wiki_reload(name=None):
 @click.command(name="threebotbuilder")
 @click.option("-p", "--push", is_flag=True, help="push to docker hub")
 @click.option("-b", "--base", is_flag=True, help="build base image as well")
+@click.option("-t", "--production", is_flag=True, help="build production image as well")
 @click.option("-c", "--cont", is_flag=True, help="don't delete continue a previously stopped run")
-def threebotbuilder(push=False, base=False, cont=False):
+def threebotbuilder(push=False, base=False, cont=False, production=False):
     """
     create the base for a 3bot
     if 3bot then will also create a 3botdev which is with the development tools inside
@@ -515,19 +516,20 @@ def threebotbuilder(push=False, base=False, cont=False):
 
     docker.image = dest
 
-    docker = e.DF.container_get(name="3botprod", delete=True, image=dest)
-    docker.install()
-    installer = IT.JumpscaleInstaller()
-    installer.repos_get(pull=False)
-    docker.jumpscale_install(branch=IT.DEFAULT_BRANCH, threebot=True)
-    docker.install_threebotserver()
+    if production:
+        docker = e.DF.container_get(name="3botprod", delete=True, image=dest)
+        docker.install()
+        installer = IT.JumpscaleInstaller()
+        installer.repos_get(pull=False)
+        docker.jumpscale_install(branch=IT.DEFAULT_BRANCH, threebot=True)
+        docker.install_threebotserver()
 
-    image = dest + "-production"
-    docker.save(image=image, clean_devel=True)
-    if push:
-        docker.push()
+        image = dest + "-production"
+        docker.save(image=image, clean_devel=True)
+        if push:
+            docker.push()
 
-    docker.image = image
+        docker.image = image
 
     print("- *OK* threebot container has been built, as image & exported")
 


### PR DESCRIPTION
Add a production image that contains a jumpscale installation and threebot installation to make the deployment of 3bot servers faster. 

Resolves https://github.com/threefoldtech/jumpscaleX_core/issues/230 