### PR TITLE
bcdb master fixes

### DIFF
--- a/JumpscaleCore/data/bcdb/BCDBFactory.py
+++ b/JumpscaleCore/data/bcdb/BCDBFactory.py
@@ -39,8 +39,10 @@ class BCDBFactory(j.baseclasses.factory_testtools):
             else:
                 if j.core.db and j.core.db.get("threebot.starting"):
                     print(" ** WAITING FOR THREEBOT TO STARTUP, STILL LOADING")
-                    j.sal.nettools.waitConnectionTest("localhost", 6380, timeout=60)
-                    self.__master = False
+                    if not j.sal.nettools.waitConnectionTest("localhost", 6380, timeout=60):
+                        self.__master = True
+                    else:
+                        self.__master = False
                 else:
                     self.__master = True
         return self.__master

--- a/JumpscaleCore/data/bcdb/BCDBFactory.py
+++ b/JumpscaleCore/data/bcdb/BCDBFactory.py
@@ -46,7 +46,7 @@ class BCDBFactory(j.baseclasses.factory_testtools):
         return self.__master
 
     def _master_set(self, val=True):
-        if True:
+        if val:
             j.core.db.set("threebot.starting", ex=120, value="1")
         else:
             j.core.db.delete("threebot.starting")

--- a/JumpscaleCore/servers/threebot/ThreebotServer.py
+++ b/JumpscaleCore/servers/threebot/ThreebotServer.py
@@ -318,12 +318,11 @@ class ThreeBotServer(j.baseclasses.object_config):
                 forever.wait()
             except KeyboardInterrupt:
                 print("KEYB INTERUPT")
-            sys.exit()
 
             # dont call stop
             # delete the fact that maybe we are still in starting mode
-            j.core.db.delete("threebot.starting")
-
+            j.data.bcdb._master_set(False)
+            sys.exit()
         else:
             if not self.startup_cmd.is_running():
                 self.startup_cmd.start()
@@ -403,7 +402,7 @@ class ThreeBotServer(j.baseclasses.object_config):
         :return:
         """
         self.startup_cmd.stop(waitstop=False, force=True)
-        j.core.db.delete("threebot.starting")
+        j.data.bcdb._master_set(False)
         self.openresty_server.stop()
 
     @property

--- a/cmds/bcdb
+++ b/cmds/bcdb
@@ -88,7 +88,7 @@ def rebuild(name=None):
     :return:
     """
 
-    j.data.bcdb.threebot_start()
+    j.data.bcdb.threebot_zdb_sonic_start()
 
     if not name:
         for bcdb in j.data.bcdb.instances.values():

--- a/cmds/bcdb
+++ b/cmds/bcdb
@@ -9,8 +9,8 @@ import click
 os.environ["LC_ALL"] = "en_US.UTF-8"
 
 
-j.core.db.delete("threebot.starting")
-j.data.bcdb._master_set()
+j.data.bcdb._master_set(False)
+j.data.bcdb._master_set(True)
 
 
 @click.group()
@@ -46,10 +46,13 @@ def delete(name=None, all=False):
             _unlock(name)
             do(name)
 
+    j.data.bcdb._master_set(False)
+
 
 @click.command()
 def unlock():
     _unlock()
+    j.data.bcdb._master_set(False)
 
 
 def _unlock():
@@ -77,6 +80,7 @@ def check(name=None):
     :return:
     """
     j.application.check()
+    j.data.bcdb._master_set(False)
 
 
 @click.command()
@@ -96,6 +100,8 @@ def rebuild(name=None):
     else:
         bcdb = j.data.bcdb.get(name=name, reset=False)
         bcdb.index_rebuild()
+
+    j.data.bcdb._master_set(False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Claim master if key `threebot.starting` is set but nothing started in time. It means that probably the key wasn't cleaned up properly.
- Refactor bcdb `_master_set` to do both set/unset 