### PR TITLE
Fixes in filecopy of ssh client and in wiregaurd client and factory

### DIFF
--- a/JumpscaleCore/tools/wireguard/WGFactory.py
+++ b/JumpscaleCore/tools/wireguard/WGFactory.py
@@ -23,7 +23,8 @@ class WGFactory(j.baseclasses.object_config_collection_testtools):
 
     def get_by_id(self, id):
         data = self._model.get(id)
-        return self._new(data.name, data)
+        if j.tools.wireguard.exists(data.name):
+            return self.get(data.name)
 
     def generate_zos_keys(self, node_public_key):
         """
@@ -32,8 +33,8 @@ class WGFactory(j.baseclasses.object_config_collection_testtools):
 
         This implementation match the format 0-OS except to be able
         to read wireguard keys into network reservations.
-        
-        :param node_public_key: hex encoded public key of 0-OS node. 
+
+        :param node_public_key: hex encoded public key of 0-OS node.
                                 This is the format you find in the explorer
         :type node_public_key: str
         :return: tuple containing 3 fields (private key, private key encrypted, public key)

--- a/JumpscaleCore/tools/wireguard/WireGuard.py
+++ b/JumpscaleCore/tools/wireguard/WireGuard.py
@@ -56,7 +56,7 @@ class WireGuard(j.baseclasses.object_config):
             if self.islocal:
                 self._executor = j.tools.executor.local
             else:
-                self._executor = j.clients.ssh.get(self.sshclient_name, client_type="pssh", autosave=False).executor
+                self._executor = j.clients.ssh.get(self.sshclient_name, autosave=False).executor
         return self._executor
 
     def install(self):


### PR DESCRIPTION
- Fix file copy in ssh client  if remote directory not found
- Fix get_by_id in wireguard factory to return the object found instead of trying to make a copy of it which is no longerr possible due to use of unique names 
- Remove use of parameters that are removed from ssh client schema