### PR TITLE
Remove connection from gedis and zdb init

### DIFF
--- a/JumpscaleCore/clients/gedis/GedisClient.py
+++ b/JumpscaleCore/clients/gedis/GedisClient.py
@@ -52,11 +52,11 @@ class GedisClient(JSConfigBase):
         self._threebot_me_ = None
         self._reset()
 
-    #     self._model.trigger_add(self._update_trigger)
-    #
-    # def _update_trigger(self, obj, action, **kwargs):
-    #     if action in ["save", "change"]:
-    #         self._reset()
+        self._model.trigger_add(self._update_trigger)
+
+    def _update_trigger(self, obj, action, **kwargs):
+        if action in ["save", "change"]:
+            self._reset()
 
     def _reset(self):
         self._redis_ = None  # connection to server

--- a/JumpscaleCore/clients/gedis/GedisClient.py
+++ b/JumpscaleCore/clients/gedis/GedisClient.py
@@ -51,7 +51,6 @@ class GedisClient(JSConfigBase):
         self._redis_ = None
         self._threebot_me_ = None
         self._reset()
-        self.reload()
 
     #     self._model.trigger_add(self._update_trigger)
     #

--- a/JumpscaleCore/clients/stor_zdb/ZDBClientBase.py
+++ b/JumpscaleCore/clients/stor_zdb/ZDBClientBase.py
@@ -24,8 +24,6 @@ class ZDBClientBase(j.baseclasses.object_config):
         if j.data.bcdb._master:
             self._model.trigger_add(self._update_trigger)
 
-        self._connect()
-
     def _connect(self):
         if self.admin:
 
@@ -56,6 +54,7 @@ class ZDBClientBase(j.baseclasses.object_config):
                 j.clients.redis.get(addr=self.addr, port=self.port, fromcache=False, ping=False)
             )
             self._select_namespace(self.nsname)
+            self._connect()
         return self._redis
 
     def _select_namespace(self, nsname=None):


### PR DESCRIPTION
Instead of attempting to connect in gedis and zdb init of the client instances, we connect when needed.

Fixes https://github.com/threefoldtech/jumpscaleX_core/issues/247 and https://github.com/threefoldtech/jumpscaleX_core/issues/242 