### PR TITLE
Remove zdb server start from bcdb import

### DIFF
--- a/JumpscaleCore/data/bcdb/BCDB.py
+++ b/JumpscaleCore/data/bcdb/BCDB.py
@@ -181,8 +181,6 @@ class BCDB(j.baseclasses.object):
         :param reset: reset the export path before exporting, defaults to True
         :type reset: bool, optional
         """
-        j.data.bcdb.threebot_zdb_sonic_start()
-
         # lazy loaded instances to export
         if self.storclient.type != "SDB":
             self.get_all()

--- a/JumpscaleCore/data/bcdb/tests/10_export.py
+++ b/JumpscaleCore/data/bcdb/tests/10_export.py
@@ -13,7 +13,7 @@ def main(self):
     kosmos 'j.data.bcdb.test(name="export")'
 
     """
-    _, zdb = j.data.bcdb.threebot_zdb_sonic_start()
+    zdb = j.servers.zdb.test_instance_start()
 
     namespaces = ["testexport_zdb", "testexport_sqlite"]
 

--- a/docs/BCDB/README.md
+++ b/docs/BCDB/README.md
@@ -156,7 +156,6 @@ assert len(result) == 1
 
 BCDB exposes an export/import functionality.
 
-When exporting, the data is by default encrypted using your key.
 
 ```python
 bcdb.export("/tmp/bcdbinstnace/)
@@ -174,11 +173,12 @@ tree /tmp/bcdbinstnace/node.1/
 ├── 30.data
 └── _schema.toml
 ```
-for each model, we export the schema, and all the objects. If you send `encryption=False`, each object will be exported as a toml file.
+for each model, we export the schema, and all the objects.
 
-To import the data back, simply call the `import_` function. This will first reset bcdb, then import all the data. Before reseting the data, it will confirm with the user. To disable this, send `interactive=False`.
+To import the data back, start the zdb server, then simply call the `import_` function. This will first reset bcdb, then import all the data. Before reseting the data, it will confirm with the user. To disable this, send `interactive=False`.
 
 ```python
+j.data.bcdb.threebot_zdb_sonic_start()
 bcdb.import_("/tmp/bcdbinstnace/")
 ```
 


### PR DESCRIPTION
Remove zdb server start from bcdb export so we can use the zdb test instance in the test and extend the docs.

https://github.com/threefoldtech/jumpscaleX_core/issues/455 