### PR TITLE
Logging improvements and fixes.

### DIFF
--- a/JumpscaleCore/tools/alerthandler/RedisAlertHandler.py
+++ b/JumpscaleCore/tools/alerthandler/RedisAlertHandler.py
@@ -101,39 +101,11 @@ class AlertHandler(j.baseclasses.object):
     def setup(self):
         if self.handle_error not in j.errorhandler.handlers:
             j.errorhandler.handlers.append(self.handle_error)
-        if self.handle_log not in j.core.myenv.loghandlers:
-            j.core.myenv.loghandlers.append(self.handle_log)
-
-    def handle_log(self, logdict):
-        j.application.inlogger = True
-        try:
-            self._handle_log(logdict)
-        except Exception as e:
-            print("**ERROR IN LOG HANDLER**")
-            print(str(e))
-        j.application.inlogger = False
 
     def _process_logdict(self, logdict):
         if "processid" not in logdict or not logdict["processid"] or logdict["processid"] == "unknown":
             logdict["processid"] = j.application.systempid
         return logdict
-
-    def _handle_log(self, logdict):
-        """handle error
-
-        :param logdict: logging dict (see jumpscaleX_core/docs/Internals/logging_errorhandling/logdict.md for keys)
-        :type logdict: dict
-        """
-
-        if "traceback" in logdict:
-            logdict.pop("traceback")
-
-        logdict = self._process_logdict(logdict)
-
-        data = self._dumps(logdict)
-
-        self.db.lpush(self._rediskey_logs, data)
-        self.db.ltrim(self._rediskey_logs, 0, 1000)
 
     def _dumps(self, data):
         if isinstance(data, str):

--- a/cmds/js_logs
+++ b/cmds/js_logs
@@ -1,0 +1,63 @@
+#! /usr/bin/env python3
+import click
+
+from Jumpscale import j
+
+
+def get_client(redis_host, redis_port, redis_secret, session, date, context):
+    client = j.clients.logger.get("js_logs")
+    if redis_host:
+        client.redis_host = redis_host
+    if redis_port:
+        client.redis_port = redis_port
+    if redis_secret:
+        client.redis_secret = redis_secret
+    if session:
+        client.session = session
+
+    client.date = date
+    client.context = context
+    return client
+
+
+@click.group()
+def cli():
+    pass
+
+
+def common_options(function):
+    click.option("--redis-host", default=None, help="redis host (defaults to localhost)")(function)
+    click.option("--redis-port", default=6379, help="redis port (defaults to 6379)")(function)
+    click.option("--redis-secret", default=None, help="redis secret (empty by default)")(function)
+    click.option("--session", default=None, help="session name (defaults to jumpscale)")(function)
+    click.option("--date", default=j.data.time.epoch, help="filter by date (epoch), defaults to today")(function)
+    click.option("--context", default="main", help="current context (can be main, error...etc)")(function)
+    return function
+
+
+@click.command()
+@common_options
+def tail(redis_host, redis_port, redis_secret, session, date, context):
+    """
+    tail logs from session
+    """
+    client = get_client(redis_host, redis_port, redis_secret, session, date, context)
+    client.tail()
+
+
+@click.command()
+@common_options
+@click.option("--path", required=True, help="output file path")
+def dump(redis_host, redis_port, redis_secret, session, date, context, path):
+    """
+    will erase the alerts in the DB
+    """
+    client = get_client(redis_host, redis_port, redis_secret, session, date, context)
+    client.dump(path)
+
+
+cli.add_command(tail)
+cli.add_command(dump)
+
+if __name__ == "__main__":
+    cli()

--- a/cmds/js_logs
+++ b/cmds/js_logs
@@ -50,7 +50,7 @@ def tail(redis_host, redis_port, redis_secret, session, date, context):
 @click.option("--path", required=True, help="output file path")
 def dump(redis_host, redis_port, redis_secret, session, date, context, path):
     """
-    will erase the alerts in the DB
+    dump logs of session to file
     """
     client = get_client(redis_host, redis_port, redis_secret, session, date, context)
     client.dump(path)


### PR DESCRIPTION
Using j.sal.fs in logging handlers causes an infinite recursion (because fs sal itself uses logging)

Resolves #466 and #464 

Also:
* Update file path for fs logger only on context switches
* Do not start another redis server only for logs as we only deal with 100 logs now.
* Keep ansi colors
* Just do push/trim every time
* Remove logging handling from alert handler (#464).
* Add js_logs (required logger client implemented at https://github.com/threefoldtech/jumpscaleX_libs/pull/56, do we need to move it to core?).

For `js_logs` command, it supports two commands, `tail` and `dump` to file for now:

```
js_logs tail
```

Or dump to file:
```
js_logs dump --path /path/to/logs.ansi
```

`js_logs` need to be in `PATH`, can simply be done by:
```
ln -s /sandbox/code/github/threefoldtech/jumpscaleX_core/cmds/js_logs /sandbox/bin/js_logs
```

Ctrl+c to stop any of them.