### PR TITLE
always start lapis on starting threebot to avoid #479

### DIFF
--- a/JumpscaleCore/servers/openresty/OpenRestyServer.py
+++ b/JumpscaleCore/servers/openresty/OpenRestyServer.py
@@ -161,9 +161,6 @@ class OpenRestyServer(j.baseclasses.factory_data):
         # compile all 1 time to lua, can do this at each start
         # j.sal.process.execute("cd %s;moonc ." % self._web_path)
         # NO LONGER NEEDED BECAUSE WE DON"T USE THE MOONSCRIPT ANY MORE
-
-        if reset:
-            self.startup_cmd.stop(force=True)
         self._log_info("Starting Lapis Server")
         if self.startup_cmd.is_running():
             self.stop()

--- a/JumpscaleCore/servers/threebot/ThreebotServer.py
+++ b/JumpscaleCore/servers/threebot/ThreebotServer.py
@@ -235,13 +235,9 @@ class ThreeBotServer(j.baseclasses.object_config):
             assert redis_server.host == "127.0.0.1"
             assert redis_server.secret == adminsecret_
             self.rack_server.add("bcdb_system_redis", redis_server.gevent_server)
-            if restart or j.sal.nettools.tcpPortConnectionTest("localhost", 80) is False:
-                self._log_info("OPENRESTY START")
-                if restart:
-                    self.openresty_server.stop()
-                self.openresty_server.start()
-            else:
-                self.openresty_server.reload()
+
+            self._log_info("OPENRESTY START")
+            self.openresty_server.start()
 
             # will also find all packages
             self._packages_core_init()


### PR DESCRIPTION
on starting threebot server it was checking if lapis is listening on port 80 or not, if it's listening it wasn't starting it, but if you didn't close lapis gracefuly, another process will be still running and will be listening on port 80, that's why it's safer to start lapis again each time 