### PR TITLE
ensure the pane and window are running in tmux_start in StartupCMD

### DIFF
--- a/JumpscaleCore/servers/startupcmd/StartupCMD.py
+++ b/JumpscaleCore/servers/startupcmd/StartupCMD.py
@@ -687,6 +687,7 @@ class StartupCMD(j.baseclasses.object_config):
     def _tmux_start(self, path):
 
         j.servers.tmux.server
+        j.servers.tmux.pane_get(window=self._pane.window.name, pane=self._pane.name)
 
         if "__" in self._pane.name:
             self._pane.kill()


### PR DESCRIPTION
Ensure tmux pane and window are running before executing startupcmd.
Solve Error in issue https://github.com/threefoldtech/jumpscaleX_core/issues/560.
