### PR TITLE
remove cached schemas in meta

### DIFF
--- a/JumpscaleCore/data/bcdb/tests/18_schema_update.py
+++ b/JumpscaleCore/data/bcdb/tests/18_schema_update.py
@@ -3,7 +3,7 @@ from Jumpscale import j
 skip = j.baseclasses.testtools._skip
 
 
-@skip("https://github.com/threefoldtech/jumpscaleX_core/issues/539")
+# @skip("https://github.com/threefoldtech/jumpscaleX_core/issues/539")
 def test_schema_update():
     """
     to run:

--- a/JumpscaleCore/data/bcdb/tests/18_schema_update.py
+++ b/JumpscaleCore/data/bcdb/tests/18_schema_update.py
@@ -3,7 +3,7 @@ from Jumpscale import j
 skip = j.baseclasses.testtools._skip
 
 
-# @skip("https://github.com/threefoldtech/jumpscaleX_core/issues/539")
+@skip("https://github.com/threefoldtech/jumpscaleX_core/issues/539")
 def test_schema_update():
     """
     to run:

--- a/JumpscaleCore/data/schema/SchemaFactory.py
+++ b/JumpscaleCore/data/schema/SchemaFactory.py
@@ -73,10 +73,8 @@ class SchemaFactory(j.baseclasses.factory_testtools, TESTTOOLS):
             self.schemas_loaded.pop(url)
             if s._md5 in self.schemas_md5:
                 self.schemas_md5.pop(s._md5)
-            if self.meta._data["url"].get(url):
-                self.meta._data["url"].pop(url)
-            if self.meta._data["md5"].get(s._md5):
-                self.meta._data["md5"].pop(s._md5)
+            self.meta._data["url"].pop(url, None)
+            self.meta._data["md5"].pop(s._md5, None)
 
     def get(self, md5=None, url=None, text=""):
         """

--- a/JumpscaleCore/data/schema/SchemaFactory.py
+++ b/JumpscaleCore/data/schema/SchemaFactory.py
@@ -73,6 +73,10 @@ class SchemaFactory(j.baseclasses.factory_testtools, TESTTOOLS):
             self.schemas_loaded.pop(url)
             if s._md5 in self.schemas_md5:
                 self.schemas_md5.pop(s._md5)
+            if self.meta._data["url"].get(url):
+                self.meta._data["url"].pop(url)
+            if self.meta._data["md5"].get(s._md5):
+                self.meta._data["md5"].pop(s._md5)
 
     def get(self, md5=None, url=None, text=""):
         """
@@ -249,9 +253,8 @@ class SchemaFactory(j.baseclasses.factory_testtools, TESTTOOLS):
             s = self.schemas_md5[md5]
             if url:
                 assert s.url == url
-            return s
-
-        s = Schema(text=schema_text, url=url, md5=md5)
+        else:
+            s = Schema(text=schema_text, url=url, md5=md5)
 
         if save:
             j.data.schema.meta.schema_set(s, newest=newest)


### PR DESCRIPTION
issue: https://github.com/threefoldtech/jumpscaleX_core/issues/680
- remove md5 and url of schema from meta on `schema_cache_remove()`