### PR TITLE
Remove mouse support from shell

### DIFF
--- a/JumpscaleCore/core/KosmosShell.py
+++ b/JumpscaleCore/core/KosmosShell.py
@@ -446,7 +446,7 @@ def ptconfig(repl):
     repl.wrap_lines = True
 
     # Mouse support.
-    repl.enable_mouse_support = True
+    repl.enable_mouse_support = False
 
     # Complete while typing. (Don't require tab before the
     # completion menu is shown.)

--- a/install/threesdk/shell.py
+++ b/install/threesdk/shell.py
@@ -217,7 +217,7 @@ def ptconfig(repl, expert=False):
     repl.wrap_lines = True
 
     # Mouse support.
-    repl.enable_mouse_support = True
+    repl.enable_mouse_support = False
 
     # Complete while typing. (Don't require tab before the
     # completion menu is shown.)


### PR DESCRIPTION
This prevents the shell from capturing mouse event allowing the terminal
to do normal selection mode making scrolling and copying easier

See: #902

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>